### PR TITLE
Format code using black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
 
 install:
   - pip install pipenv
-  - pipenv install
+  - pipenv install --dev
 
 script:
   - pipenv run nosetests --with-doctest
+  - pipenv run python -m black megyr/*.py --check

--- a/Pipfile
+++ b/Pipfile
@@ -14,3 +14,6 @@ black = "*"
 
 [requires]
 python_version = "3.6"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pystache = "*"
 [dev-packages]
 sphinx = "*"
 nose = "*"
+black = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,55 +18,51 @@
     "default": {
         "numpy": {
             "hashes": [
-                "sha256:0b0dd8f47fb177d00fa6ef2d58783c4f41ad3126b139c91dd2f7c4b3fdf5e9a5",
-                "sha256:25ffe71f96878e1da7e014467e19e7db90ae7d4e12affbc73101bcf61785214e",
-                "sha256:26efd7f7d755e6ca966a5c0ac5a930a87dbbaab1c51716ac26a38f42ecc9bc4b",
-                "sha256:28b1180c758abf34a5c3fea76fcee66a87def1656724c42bb14a6f9717a5bdf7",
-                "sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c",
-                "sha256:30c84e3a62cfcb9e3066f25226e131451312a044f1fe2040e69ce792cb7de418",
-                "sha256:4650d94bb9c947151737ee022b934b7d9a845a7c76e476f3e460f09a0c8c6f39",
-                "sha256:4dd830a11e8724c9c9379feed1d1be43113f8bcce55f47ea7186d3946769ce26",
-                "sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2",
-                "sha256:62d22566b3e3428dfc9ec972014c38ed9a4db4f8969c78f5414012ccd80a149e",
-                "sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c",
-                "sha256:75fcd60d682db3e1f8fbe2b8b0c6761937ad56d01c1dc73edf4ef2748d5b6bc4",
-                "sha256:9395b0a41e8b7e9a284e3be7060db9d14ad80273841c952c83a5afc241d2bd98",
-                "sha256:9e37c35fc4e9410093b04a77d11a34c64bf658565e30df7cbe882056088a91c1",
-                "sha256:a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e",
-                "sha256:b46554ad4dafb2927f88de5a1d207398c5385edbb5c84d30b3ef187c4a3894d8",
-                "sha256:c867eeccd934920a800f65c6068acdd6b87e80d45cd8c8beefff783b23cdc462",
-                "sha256:dd0667f5be56fb1b570154c2c0516a528e02d50da121bbbb2cbb0b6f87f59bc2",
-                "sha256:de2b1c20494bdf47f0160bd88ed05f5e48ae5dc336b8de7cfade71abcc95c0b9",
-                "sha256:f1df7b2b7740dd777571c732f98adb5aad5450aee32772f1b39249c8a50386f6",
-                "sha256:ffca69e29079f7880c5392bf675eb8b4146479d976ae1924d01cd92b04cccbcc"
+                "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
+                "sha256:1b0ece94018ae21163d1f651b527156e1f03943b986188dd81bc7e066eae9d1c",
+                "sha256:2e40be731ad618cb4974d5ba60d373cdf4f1b8dcbf1dcf4d9dff5e212baf69c5",
+                "sha256:4ba59db1fcc27ea31368af524dcf874d9277f21fd2e1f7f1e2e0c75ee61419ed",
+                "sha256:59ca9c6592da581a03d42cc4e270732552243dc45e87248aa8d636d53812f6a5",
+                "sha256:5e0feb76849ca3e83dd396254e47c7dba65b3fa9ed3df67c2556293ae3e16de3",
+                "sha256:6d205249a0293e62bbb3898c4c2e1ff8a22f98375a34775a259a0523111a8f6c",
+                "sha256:6fcc5a3990e269f86d388f165a089259893851437b904f422d301cdce4ff25c8",
+                "sha256:82847f2765835c8e5308f136bc34018d09b49037ec23ecc42b246424c767056b",
+                "sha256:87902e5c03355335fc5992a74ba0247a70d937f326d852fc613b7f53516c0963",
+                "sha256:9ab21d1cb156a620d3999dd92f7d1c86824c622873841d6b080ca5495fa10fef",
+                "sha256:a1baa1dc8ecd88fb2d2a651671a84b9938461e8a8eed13e2f0a812a94084d1fa",
+                "sha256:a244f7af80dacf21054386539699ce29bcc64796ed9850c99a34b41305630286",
+                "sha256:a35af656a7ba1d3decdd4fae5322b87277de8ac98b7d9da657d9e212ece76a61",
+                "sha256:b1fe1a6f3a6f355f6c29789b5927f8bd4f134a4bd9a781099a7c4f66af8850f5",
+                "sha256:b5ad0adb51b2dee7d0ee75a69e9871e2ddfb061c73ea8bc439376298141f77f5",
+                "sha256:ba3c7a2814ec8a176bb71f91478293d633c08582119e713a0c5351c0f77698da",
+                "sha256:cd77d58fb2acf57c1d1ee2835567cd70e6f1835e32090538f17f8a3a99e5e34b",
+                "sha256:cdb3a70285e8220875e4d2bc394e49b4988bdb1298ffa4e0bd81b2f613be397c",
+                "sha256:deb529c40c3f1e38d53d5ae6cd077c21f1d49e13afc7936f7f868455e16b64a0",
+                "sha256:e7894793e6e8540dbeac77c87b489e331947813511108ae097f1715c018b8f3d"
             ],
-            "version": "==1.17.3"
+            "version": "==1.18.2"
         },
         "pandas": {
             "hashes": [
-                "sha256:11975fad9edbdb55f1a560d96f91830e83e29bed6ad5ebf506abda09818eaf60",
-                "sha256:12e13d127ca1b585dd6f6840d3fe3fa6e46c36a6afe2dbc5cb0b57032c902e31",
-                "sha256:1c87fcb201e1e06f66e23a61a5fea9eeebfe7204a66d99df24600e3f05168051",
-                "sha256:242e9900de758e137304ad4b5663c2eff0d798c2c3b891250bd0bd97144579da",
-                "sha256:26c903d0ae1542890cb9abadb4adcb18f356b14c2df46e4ff657ae640e3ac9e7",
-                "sha256:2e1e88f9d3e5f107b65b59cd29f141995597b035d17cc5537e58142038942e1a",
-                "sha256:31b7a48b344c14691a8e92765d4023f88902ba3e96e2e4d0364d3453cdfd50db",
-                "sha256:4fd07a932b4352f8a8973761ab4e84f965bf81cc750fb38e04f01088ab901cb8",
-                "sha256:5b24ca47acf69222e82530e89111dd9d14f9b970ab2cd3a1c2c78f0c4fbba4f4",
-                "sha256:647b3b916cc8f6aeba240c8171be3ab799c3c1b2ea179a3be0bd2712c4237553",
-                "sha256:66b060946046ca27c0e03e9bec9bba3e0b918bafff84c425ca2cc2e157ce121e",
-                "sha256:6efa9fa6e1434141df8872d0fa4226fc301b17aacf37429193f9d70b426ea28f",
-                "sha256:be4715c9d8367e51dbe6bc6d05e205b1ae234f0dc5465931014aa1c4af44c1ba",
-                "sha256:bea90da782d8e945fccfc958585210d23de374fa9294a9481ed2abcef637ebfc",
-                "sha256:d318d77ab96f66a59e792a481e2701fba879e1a453aefeebdb17444fe204d1ed",
-                "sha256:d785fc08d6f4207437e900ffead930a61e634c5e4f980ba6d3dc03c9581748c7",
-                "sha256:de9559287c4fe8da56e8c3878d2374abc19d1ba2b807bfa7553e912a8e5ba87c",
-                "sha256:f4f98b190bb918ac0bc0e3dd2ab74ff3573da9f43106f6dba6385406912ec00f",
-                "sha256:f71f1a7e2d03758f6e957896ed696254e2bc83110ddbc6942018f1a232dd9dad",
-                "sha256:fb944c8f0b0ab5c1f7846c686bc4cdf8cde7224655c12edcd59d5212cd57bec0"
+                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
+                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
+                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
+                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
+                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
+                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
+                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
+                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
+                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
+                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
+                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
+                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
+                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
+                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
+                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
+                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
             ],
             "index": "pypi",
-            "version": "==0.23.4"
+            "version": "==1.0.3"
         },
         "pystache": {
             "hashes": [
@@ -77,10 +73,10 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
@@ -91,10 +87,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.12.0"
+            "version": "==1.14.0"
         }
     },
     "develop": {
@@ -107,17 +103,17 @@
         },
         "babel": {
             "hashes": [
-                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
-                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
+                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
+                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
-            "version": "==2.7.0"
+            "version": "==2.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -128,32 +124,31 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
-            "version": "==0.15.2"
+            "version": "==0.16"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "imagesize": {
             "hashes": [
-                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
-                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
+                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
+                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
-                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
+                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
             ],
-            "version": "==2.10.3"
+            "version": "==2.11.1"
         },
         "markupsafe": {
             "hashes": [
@@ -161,13 +156,16 @@
                 "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
                 "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
@@ -184,7 +182,9 @@
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
             "version": "==1.1.1"
         },
@@ -199,24 +199,24 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
             ],
-            "version": "==19.2"
+            "version": "==20.3"
         },
         "pygments": {
             "hashes": [
-                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
-                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
-            "version": "==2.4.2"
+            "version": "==2.6.1"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.6"
         },
         "pytz": {
             "hashes": [
@@ -227,17 +227,17 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.12.0"
+            "version": "==1.14.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -248,26 +248,60 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
-                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
+                "sha256:b4c750d546ab6d7e05bdff6ac24db8ae3e8b8253a3569b754e445110a0a12b66",
+                "sha256:fc312670b56cb54920d6cc2ced455a22a547910de10b3142276495ced49231cb"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "version": "==2.4.4"
         },
-        "sphinxcontrib-websupport": {
+        "sphinxcontrib-applehelp": {
             "hashes": [
-                "sha256:1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc",
-                "sha256:e02f717baf02d0b6c3dd62cf81232ffca4c9d5c331e03766982e3ff9f1d2bc3f"
+                "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
+                "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
-            "version": "==1.1.2"
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
+                "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
+            ],
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
+                "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
+            ],
+            "version": "==1.0.3"
+        },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-qthelp": {
+            "hashes": [
+                "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
+                "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
+            ],
+            "version": "==1.0.3"
+        },
+        "sphinxcontrib-serializinghtml": {
+            "hashes": [
+                "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
+                "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
+            ],
+            "version": "==1.1.4"
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "index": "pypi",
-            "version": "==1.24.2"
+            "version": "==1.25.8"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "72ac76109a2ea895340e3ffb115b79b399c99c420679752b5c9ec335e4098d69"
+            "sha256": "4792e6aaef3fa70d0bf262220bc8a2649b995dd7698016d1a0309aebe571c8e1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,35 @@
         ]
     },
     "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+            ],
+            "version": "==7.1.1"
+        },
         "numpy": {
             "hashes": [
                 "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
@@ -64,6 +93,13 @@
             "index": "pypi",
             "version": "==1.0.3"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
+                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
+            ],
+            "version": "==0.7.0"
+        },
         "pystache": {
             "hashes": [
                 "sha256:f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a"
@@ -85,12 +121,72 @@
             ],
             "version": "==2019.3"
         },
+        "regex": {
+            "hashes": [
+                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
+                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
+                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
+                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
+                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
+                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
+                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
+                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
+                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
+                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
+                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
+                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
+                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
+                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
+                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
+                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
+                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
+                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
+                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
+                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
+                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
+            ],
+            "version": "==2020.2.20"
+        },
         "six": {
             "hashes": [
                 "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
                 "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
             "version": "==1.14.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e",
+                "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"
+            ],
+            "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
         }
     },
     "develop": {
@@ -101,12 +197,34 @@
             ],
             "version": "==0.7.12"
         },
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
         "babel": {
             "hashes": [
                 "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
                 "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
             "version": "==2.8.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
         },
         "certifi": {
             "hashes": [
@@ -121,6 +239,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+            ],
+            "version": "==7.1.1"
         },
         "docutils": {
             "hashes": [
@@ -145,10 +270,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
-                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
+                "sha256:c10142f819c2d22bdcd17548c46fa9b77cf4fda45097854c689666bf425e7484",
+                "sha256:c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668"
             ],
-            "version": "==2.11.1"
+            "version": "==3.0.0a1"
         },
         "markupsafe": {
             "hashes": [
@@ -204,6 +329,13 @@
             ],
             "version": "==20.3"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
+                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
+            ],
+            "version": "==0.7.0"
+        },
         "pygments": {
             "hashes": [
                 "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
@@ -224,6 +356,32 @@
                 "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
             ],
             "version": "==2019.3"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
+                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
+                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
+                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
+                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
+                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
+                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
+                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
+                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
+                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
+                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
+                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
+                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
+                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
+                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
+                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
+                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
+                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
+                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
+                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
+                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
+            ],
+            "version": "==2020.2.20"
         },
         "requests": {
             "hashes": [
@@ -248,11 +406,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:b4c750d546ab6d7e05bdff6ac24db8ae3e8b8253a3569b754e445110a0a12b66",
-                "sha256:fc312670b56cb54920d6cc2ced455a22a547910de10b3142276495ced49231cb"
+                "sha256:588ab849305802b0d68e550c9fb7de25555e8b0ce82ceaa5c2826aa518e97a75",
+                "sha256:5f8c74f548865d7ea0cd3c496da98d41ec822f229445281017630d290b8c0851"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==3.0.0b1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -295,6 +453,40 @@
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
             "version": "==1.1.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e",
+                "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"
+            ],
+            "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
         },
         "urllib3": {
             "hashes": [

--- a/megyr/config_validation.py
+++ b/megyr/config_validation.py
@@ -1,23 +1,60 @@
 def validate_config(config):
     errors = []
 
-    assert_to_list(errors, "input" in config, "[no_input] Could not find \"input\" section in config. \"input\" section must be present in order to run MESA or GYRE.")
-    assert_to_list(errors, "stages" in config, "[no_stages] Could not find \"stages\" section in config. \"stages\" section must be present in order to run MESA or GYRE.")
+    assert_to_list(
+        errors,
+        "input" in config,
+        '[no_input] Could not find "input" section in config. "input" section must be present in order to run MESA or GYRE.',
+    )
+    assert_to_list(
+        errors,
+        "stages" in config,
+        '[no_stages] Could not find "stages" section in config. "stages" section must be present in order to run MESA or GYRE.',
+    )
 
-    assert_to_list(errors, nested_in(config, ["input", "mesa_configs"]), "[no_mesa_configs] Could not find \"mesa_configs\" setting in \"input\" section in config. The \"mesa_configs\" setting must be present in order to run MESA.")
+    assert_to_list(
+        errors,
+        nested_in(config, ["input", "mesa_configs"]),
+        '[no_mesa_configs] Could not find "mesa_configs" setting in "input" section in config. The "mesa_configs" setting must be present in order to run MESA.',
+    )
 
     if should_run_gyre(config):
-        assert_to_list(errors, nested_in(config, ["stages", "gyre_params"]), "[no_gyre_params] Could not find \"gyre_params\" setting in \"stages\" section of config. GYRE is set to run, but needs this setting to know what value combinations to try.")
+        assert_to_list(
+            errors,
+            nested_in(config, ["stages", "gyre_params"]),
+            '[no_gyre_params] Could not find "gyre_params" setting in "stages" section of config. GYRE is set to run, but needs this setting to know what value combinations to try.',
+        )
     else:
         # Check for GYRE settings present when GYRE is not set to run
-        gyre_missing_msg = "[gyre_not_enabled] Found \"{}\" setting in \"{}\" section of config even though GYRE is not enabled. \"gyre_config\" in the \"input\" section must be specified in order to run GYRE."
-        assert_to_list(errors, not nested_in(config, ["output", "gyre_oscillations_summary_file"]), gyre_missing_msg.format("gyre_oscillations_summary_file", "output"))
-        assert_to_list(errors, not nested_in(config, ["settings", "gyre_location"]), gyre_missing_msg.format("gyre_location", "settings"))
-        assert_to_list(errors, not nested_in(config, ["settings", "gyre_mp_threads"]), gyre_missing_msg.format("gyre_mp_threads", "settings"))
-        assert_to_list(errors, not nested_in(config, ["stages", "gyre_params"]), gyre_missing_msg.format("gyre_params", "stages"))
-        assert_to_list(errors, not nested_in(config, ["stages", "gyre_derived"]), gyre_missing_msg.format("gyre_derived", "stages"))
+        gyre_missing_msg = '[gyre_not_enabled] Found "{}" setting in "{}" section of config even though GYRE is not enabled. "gyre_config" in the "input" section must be specified in order to run GYRE.'
+        assert_to_list(
+            errors,
+            not nested_in(config, ["output", "gyre_oscillations_summary_file"]),
+            gyre_missing_msg.format("gyre_oscillations_summary_file", "output"),
+        )
+        assert_to_list(
+            errors,
+            not nested_in(config, ["settings", "gyre_location"]),
+            gyre_missing_msg.format("gyre_location", "settings"),
+        )
+        assert_to_list(
+            errors,
+            not nested_in(config, ["settings", "gyre_mp_threads"]),
+            gyre_missing_msg.format("gyre_mp_threads", "settings"),
+        )
+        assert_to_list(
+            errors,
+            not nested_in(config, ["stages", "gyre_params"]),
+            gyre_missing_msg.format("gyre_params", "stages"),
+        )
+        assert_to_list(
+            errors,
+            not nested_in(config, ["stages", "gyre_derived"]),
+            gyre_missing_msg.format("gyre_derived", "stages"),
+        )
 
     return errors
+
 
 def set_defaults(config):
     ### Output
@@ -25,7 +62,11 @@ def set_defaults(config):
         nested_put(config, ["output", "output_dir"], "out")
 
     if not nested_in(config, ["output", "mesa_profile_summary_file"]):
-        nested_put(config, ["output", "mesa_profile_summary_file"], "mesa_profile_attributes.csv")
+        nested_put(
+            config,
+            ["output", "mesa_profile_summary_file"],
+            "mesa_profile_attributes.csv",
+        )
 
     ### Settings
     if not nested_in(config, ["settings", "mesa_star_location"]):
@@ -34,16 +75,24 @@ def set_defaults(config):
     if not nested_in(config, ["settings", "gyre_location"]):
         nested_put(config, ["settings", "gyre_location"], "$GYRE_DIR/bin/gyre")
 
-    if not nested_in(config, ["settings", "gyre_mp_threads"]) and \
-            nested_in(config, ["settings", "mesa_mp_threads"]):
-        nested_put(config, ["settings", "gyre_mp_threads"], config["settings"]["mesa_mp_threads"])
+    if not nested_in(config, ["settings", "gyre_mp_threads"]) and nested_in(
+        config, ["settings", "mesa_mp_threads"]
+    ):
+        nested_put(
+            config,
+            ["settings", "gyre_mp_threads"],
+            config["settings"]["mesa_mp_threads"],
+        )
+
 
 def assert_to_list(errors, condition, message):
     if not condition:
         errors.append((message))
 
+
 def should_run_gyre(config):
     return nested_in(config, ["input", "gyre_config"])
+
 
 def nested_in(config, nested_keys):
     """
@@ -69,6 +118,7 @@ def nested_in(config, nested_keys):
             return False
 
     return True
+
 
 def nested_put(config, nested_keys, value):
     """

--- a/megyr/gyre.py
+++ b/megyr/gyre.py
@@ -2,7 +2,20 @@ import os.path
 
 from . import util
 
-def run_gyre(config, mesa_comb, mesa_data, gyre_comb, work_dir, output_dir, mesa_dir_name, logs_dir_name, gyre_dir_name, gyre_prefix, gyre_ad_output_summary):
+
+def run_gyre(
+    config,
+    mesa_comb,
+    mesa_data,
+    gyre_comb,
+    work_dir,
+    output_dir,
+    mesa_dir_name,
+    logs_dir_name,
+    gyre_dir_name,
+    gyre_prefix,
+    gyre_ad_output_summary,
+):
     mesa_dir = os.path.join(output_dir, mesa_dir_name)
 
     gyre_dir = os.path.join(mesa_dir, gyre_dir_name)
@@ -12,15 +25,33 @@ def run_gyre(config, mesa_comb, mesa_data, gyre_comb, work_dir, output_dir, mesa
 
     derived["ad_output_summary_file"] = gyre_ad_output_summary
 
-    gyre_config = create_gyre_config(config, mesa_comb, derived, work_dir, output_dir, mesa_dir_name, logs_dir_name, gyre_prefix, gyre_dir_name)
+    gyre_config = create_gyre_config(
+        config,
+        mesa_comb,
+        derived,
+        work_dir,
+        output_dir,
+        mesa_dir_name,
+        logs_dir_name,
+        gyre_prefix,
+        gyre_dir_name,
+    )
 
-    exec_gyre(config["settings"]["gyre_location"], output_dir, mesa_dir_name, gyre_dir_name, gyre_config)
+    exec_gyre(
+        config["settings"]["gyre_location"],
+        output_dir,
+        mesa_dir_name,
+        gyre_dir_name,
+        gyre_config,
+    )
+
 
 def extract_additional_values(config, mesa_comb, mesa_data, gyre_comb):
     if "gyre_derived" in config["stages"]:
         return config["stages"]["gyre_derived"](mesa_comb, mesa_data, gyre_comb)
 
     return dict(gyre_comb)
+
 
 def create_gyre_prefix(gyre_comb):
     """
@@ -40,14 +71,27 @@ def create_gyre_prefix(gyre_comb):
 
     return name
 
-def create_gyre_config(config, mesa_comb, gyre_comb, work_dir, output_dir, mesa_dir_name, logs_dir_name, gyre_prefix, gyre_dir_name):
+
+def create_gyre_config(
+    config,
+    mesa_comb,
+    gyre_comb,
+    work_dir,
+    output_dir,
+    mesa_dir_name,
+    logs_dir_name,
+    gyre_prefix,
+    gyre_dir_name,
+):
     end = -1 * len(".mustache")
 
     config_file = config["input"]["gyre_config"]
     config_file_in = os.path.join(work_dir, config_file)
 
     config_file_out_name = config_file[:end] + "_" + gyre_prefix
-    config_file_out = os.path.join(output_dir, mesa_dir_name, gyre_dir_name, config_file_out_name)
+    config_file_out = os.path.join(
+        output_dir, mesa_dir_name, gyre_dir_name, config_file_out_name
+    )
 
     data = mesa_comb.copy()
     data["logs_dir"] = logs_dir_name
@@ -61,6 +105,7 @@ def create_gyre_config(config, mesa_comb, gyre_comb, work_dir, output_dir, mesa_
         out.write(applied_contents)
 
     return config_file_out_name
+
 
 def exec_gyre(gyre_location, output_dir, mesa_dir_name, gyre_dir_name, gyre_config):
     gyre_dir = os.path.join(output_dir, mesa_dir_name, gyre_dir_name)

--- a/megyr/mesa.py
+++ b/megyr/mesa.py
@@ -5,6 +5,7 @@ import pandas as pd
 from . import profile
 from . import util
 
+
 def run_mesa(config, comb, work_dir, output_dir, mesa_dir_name, logs_dir_name):
     mesa_dir = os.path.join(output_dir, mesa_dir_name)
     util.create_dir(mesa_dir)
@@ -13,9 +14,12 @@ def run_mesa(config, comb, work_dir, output_dir, mesa_dir_name, logs_dir_name):
 
     derived = extract_additional_values(config, comb)
 
-    create_mesa_configs(config, derived, work_dir, output_dir, mesa_dir_name, logs_dir_name)
+    create_mesa_configs(
+        config, derived, work_dir, output_dir, mesa_dir_name, logs_dir_name
+    )
 
     exec_mesa(config, work_dir, output_dir, mesa_dir_name)
+
 
 def create_mesa_dir_name(comb):
     """
@@ -34,11 +38,13 @@ def create_mesa_dir_name(comb):
 
     return dir_name
 
+
 def extract_additional_values(config, mesa_comb):
     if "mesa_derived" in config["stages"]:
         return config["stages"]["mesa_derived"](mesa_comb)
 
     return dict(mesa_comb)
+
 
 def setup_mesa_dir(output_dir, mesa_dir_name, logs_dir_name):
     logs_dir = os.path.join(output_dir, mesa_dir_name, logs_dir_name)
@@ -47,7 +53,10 @@ def setup_mesa_dir(output_dir, mesa_dir_name, logs_dir_name):
 
     return logs_dir_name
 
-def create_mesa_configs(config, comb, work_dir, output_dir, mesa_dir_name, logs_dir_name):
+
+def create_mesa_configs(
+    config, comb, work_dir, output_dir, mesa_dir_name, logs_dir_name
+):
     end = -1 * len(".mustache")
 
     for config_file in config["input"]["mesa_configs"]:
@@ -62,14 +71,16 @@ def create_mesa_configs(config, comb, work_dir, output_dir, mesa_dir_name, logs_
         with open(config_file_out, "w") as out:
             out.write(applied_contents)
 
+
 def exec_mesa(config, work_dir, output_dir, mesa_dir_name):
     mesa_dir = os.path.join(output_dir, mesa_dir_name)
 
     mesa_command = os.path.abspath(
-	os.path.join(work_dir, config["settings"]["mesa_star_location"])
+        os.path.join(work_dir, config["settings"]["mesa_star_location"])
     )
 
     util.run_in_dir(mesa_command, mesa_dir)
+
 
 def get_mesa_data(config, output_dir, mesa_dir_name, logs_dir_name):
     logs_dir = os.path.join(output_dir, mesa_dir_name, logs_dir_name)

--- a/megyr/oscillations_summary.py
+++ b/megyr/oscillations_summary.py
@@ -1,14 +1,20 @@
 import pandas as pd
 
-def read_oscillations_summary_file(filepath, attributes_start_row=2, data_start_row=5, column_width=25):
+
+def read_oscillations_summary_file(
+    filepath, attributes_start_row=2, data_start_row=5, column_width=25
+):
     num_attributes = get_num_attributes(filepath, attributes_start_row)
 
     attr_widths = [column_width for _ in range(0, num_attributes)]
 
-    attributes = pd.read_fwf(filepath, skiprows=attributes_start_row, nrows=1, widths=attr_widths)
+    attributes = pd.read_fwf(
+        filepath, skiprows=attributes_start_row, nrows=1, widths=attr_widths
+    )
     data = pd.read_fwf(filepath, skiprows=data_start_row)
 
     return OscillationsSummary(attributes, data)
+
 
 def get_num_attributes(filepath, attributes_start_row):
     with open(filepath) as f:
@@ -16,7 +22,10 @@ def get_num_attributes(filepath, attributes_start_row):
             if i == attributes_start_row - 1:
                 return len(line.split())
 
-    raise Exception("Unable to find attributes column number line in oscillations summary file.")
+    raise Exception(
+        "Unable to find attributes column number line in oscillations summary file."
+    )
+
 
 class OscillationsSummary(object):
     def __init__(self, attributes, data):
@@ -30,7 +39,11 @@ class OscillationsSummary(object):
         if self.has_attribute(attr):
             return self.attributes[attr].iloc[0]
         else:
-            raise KeyError("Attribute \"" + attr + "\" is not a valid attribute for this oscillations summary.")
+            raise KeyError(
+                'Attribute "'
+                + attr
+                + '" is not a valid attribute for this oscillations summary.'
+            )
 
     def has_attribute(self, attr):
         return attr in list(self.attributes.columns.values)

--- a/megyr/parameters.py
+++ b/megyr/parameters.py
@@ -16,6 +16,7 @@ def create_grid(values, rows, params):
 
     return combinations
 
+
 def process_params(values, rows, raw_params):
     params = {}
     for key in raw_params:
@@ -24,19 +25,21 @@ def process_params(values, rows, raw_params):
         if isinstance(value, list):
             params[key] = set(value)
         elif isinstance(value, dict):
-            assert("type" in value)
+            assert "type" in value
             if value["type"] == "where":
-                assert("check" in value)
-                assert("then" in value)
+                assert "check" in value
+                assert "then" in value
 
-                assert(
-                    "gte" in value or "gt" in value or
-                    "lte" in value or "lt" in value or
-                    "eq" in value
+                assert (
+                    "gte" in value
+                    or "gt" in value
+                    or "lte" in value
+                    or "lt" in value
+                    or "eq" in value
                 )
 
-                assert(value["check"] in rows.columns)
-                assert(value["then"] in rows.columns)
+                assert value["check"] in rows.columns
+                assert value["then"] in rows.columns
 
                 check = value["check"]
                 then = value["then"]
@@ -61,6 +64,7 @@ def process_params(values, rows, raw_params):
 
     return params
 
+
 def generate_param_combinations(params):
     remaining = list(params.keys())
     chosen = {}
@@ -69,6 +73,7 @@ def generate_param_combinations(params):
     generate_param_combinations_h(params, remaining, chosen, combinations)
 
     return combinations
+
 
 def generate_param_combinations_h(params, remaining, chosen, combinations):
     if len(remaining) == 0:
@@ -83,4 +88,3 @@ def generate_param_combinations_h(params, remaining, chosen, combinations):
         new_chosen[p] = v
 
         generate_param_combinations_h(params, remaining[1:], new_chosen, combinations)
-

--- a/megyr/profile.py
+++ b/megyr/profile.py
@@ -2,6 +2,7 @@ import os.path
 
 import pandas as pd
 
+
 def read_num_profiles(filepath, column_length=12):
     with open(filepath, "r") as f:
         first_part = f.readline()[:column_length]
@@ -10,7 +11,10 @@ def read_num_profiles(filepath, column_length=12):
 
         return int(no_spaces)
 
-def read_all_profile_attributes(logs_dir, num_profiles, profile_prefix="profile", profile_suffix=".data"):
+
+def read_all_profile_attributes(
+    logs_dir, num_profiles, profile_prefix="profile", profile_suffix=".data"
+):
     attributes = pd.DataFrame()
     for i in range(1, num_profiles + 1):
         name = profile_prefix + str(i) + profile_suffix
@@ -23,11 +27,15 @@ def read_all_profile_attributes(logs_dir, num_profiles, profile_prefix="profile"
 
     return attributes
 
-def read_profile_file(filepath, attributes_start_row=1, data_start_row=5, read_data=True):
+
+def read_profile_file(
+    filepath, attributes_start_row=1, data_start_row=5, read_data=True
+):
     attributes = pd.read_fwf(filepath, skiprows=attributes_start_row, nrows=1)
     data = pd.read_fwf(filepath, skiprows=data_start_row) if read_data else None
 
     return MESAProfile(attributes, data)
+
 
 class MESAProfile(object):
     def __init__(self, attributes, data):
@@ -41,7 +49,11 @@ class MESAProfile(object):
         if self.has_attribute(attr):
             return self.attributes[attr].iloc[0]
         else:
-            raise KeyError("Attribute \"" + attr + "\" is not a valid attribute for this MESA profile.")
+            raise KeyError(
+                'Attribute "'
+                + attr
+                + '" is not a valid attribute for this MESA profile.'
+            )
 
     def has_attribute(self, attr):
         return attr in list(self.attributes.columns.values)

--- a/megyr/util.py
+++ b/megyr/util.py
@@ -10,15 +10,19 @@ import pystache
 
 MP_THREADS_ENV_VAR = "OMP_NUM_THREADS"
 
+
 def create_dir(path):
     os.makedirs(path, exist_ok=True)
+
 
 def run_in_dir(command, directory):
     subprocess.check_call(command, cwd=directory, shell=True)
 
+
 def render_mustache_file(f, values):
     renderer = pystache.Renderer()
     return renderer.render_path(f, values)
+
 
 def load_py_module_from_file(name, filepath):
     spec = importlib.util.spec_from_file_location(name, filepath)
@@ -28,23 +32,29 @@ def load_py_module_from_file(name, filepath):
 
     return new_module
 
+
 def set_num_mp_threads(num):
-    assert(num > 0)
+    assert num > 0
 
     os.environ[MP_THREADS_ENV_VAR] = str(num)
+
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
+
 def print_runtime_error_divider():
     eprint("------------------------")
+
 
 class DataFrameAggregator(object):
     def __init__(self, should_read):
         self.data = pd.DataFrame()
         self.should_read = should_read
 
-    def append_from_file(self, filepath, read_function=pd.read_csv, transform_func=lambda r: r):
+    def append_from_file(
+        self, filepath, read_function=pd.read_csv, transform_func=lambda r: r
+    ):
         if self.should_read:
             new_rows = read_function(filepath)
 
@@ -56,4 +66,6 @@ class DataFrameAggregator(object):
         if self.should_read:
             self.data.to_csv(filepath, index=False)
         else:
-            raise Exception("Tried to write out DataFrameAggregator that has reading disabled.")
+            raise Exception(
+                "Tried to write out DataFrameAggregator that has reading disabled."
+            )


### PR DESCRIPTION
Format all of the python code using the `black` code formatting utility. Also add a stage to the Travis CI build to check that all of the code is corr4ectly formatted.

This should help to keep the code formatting consistent across the codebase.